### PR TITLE
Improved Paystack settings page as per GiveWP standards

### DIFF
--- a/admin/class-paystack-give-admin.php
+++ b/admin/class-paystack-give-admin.php
@@ -55,6 +55,8 @@ class Paystack_Give_Admin
         $this->plugin_name = $plugin_name;
         $this->version = $version;
 
+        add_filter( 'give_get_sections_gateways', [ $this, 'register_sections' ] );
+        add_filter( 'give_get_settings_gateways', [ $this, 'register_settings' ] );
     }
 
     /**
@@ -148,5 +150,94 @@ class Paystack_Give_Admin
         include_once 'partials/paystack-give-admin-display.php';
     }
 
+    /**
+     * Register Admin Section.
+     *
+     * @param array $sections List of sections.
+     *
+     * @since  1.2.1
+     * @access public
+     *
+     * @return array
+     */
+    public function register_sections( $sections ) {
+        $sections['paystack'] = esc_html__( 'Paystack', 'paystack-give' );
 
+        return $sections;
+    }
+
+    /**
+     * Register Admin Settings.
+     *
+     * @param array $settings List of settings.
+     *
+     * @since  1.0.0
+     * @access public
+     *
+     * @return array
+     */
+    public function register_settings( $settings ) {
+        $current_section = give_get_current_setting_section();
+
+        switch ( $current_section ) {
+            case 'paystack':
+                $settings = [
+                    [
+                        'type' => 'title',
+                        'id'   => 'give_title_gateway_settings_paystack',
+                    ],
+                    [
+                        'name' => esc_html__( 'Paystack', 'paystack-give' ),
+                        'desc' => '',
+                        'type' => 'give_title',
+                        'id'   => 'give_title_paystack',
+                    ],
+                    [
+                        'name'        => esc_html__( 'Test Secret Key', 'paystack-give' ),
+                        'desc'        => esc_html__( 'Enter your Paystack Test Secret Key', 'paystack-give' ),
+                        'id'          => 'paystack_test_secret_key',
+                        'type'        => 'text',
+                        'row_classes' => 'give-paystack-test-secret-key',
+                    ],
+                    [
+                        'name'        => esc_html__( 'Test Public Key', 'paystack-give' ),
+                        'desc'        => esc_html__( 'Enter your Paystack Test Public Key', 'paystack-give' ),
+                        'id'          => 'paystack_test_public_key',
+                        'type'        => 'text',
+                        'row_classes' => 'give-paystack-test-public-key',
+                    ],
+                    [
+                        'name'        => esc_html__( 'Live Secret Key', 'paystack-give' ),
+                        'desc'        => esc_html__( 'Enter your Paystack Live Secret Key', 'paystack-give' ),
+                        'id'          => 'paystack_live_secret_key',
+                        'type'        => 'text',
+                        'row_classes' => 'give-paystack-live-secret-key',
+                    ],
+                    [
+                        'name'        => esc_html__( 'Live Public Key', 'paystack-give' ),
+                        'desc'        => esc_html__( 'Enter your Paystack Live Public Key', 'paystack-give' ),
+                        'id'          => 'paystack_live_public_key',
+                        'type'        => 'text',
+                        'row_classes' => 'give-paystack-live-public-key',
+                    ],
+                    [
+                        'name'    => esc_html__( 'Billing Details', 'paystack-give' ),
+                        'desc'    => esc_html__( 'This will enable you to collect donor details. This is not required by Paystack (except email) but you might need to collect all information for record purposes', 'paystack-give' ),
+                        'id'      => 'paystack_billing_details',
+                        'type'    => 'radio_inline',
+                        'default' => 'disabled',
+                        'options' => [
+                            'enabled'  => esc_html__( 'Enabled', 'paystack-give' ),
+                            'disabled' => esc_html__( 'Disabled', 'paystack-give' ),
+                        ],
+                    ],
+                    [
+                        'type' => 'sectionend',
+                        'id'   => 'give_title_gateway_settings_paystack',
+                    ]
+                ];
+                break;
+        }
+        return $settings;
+    }
 }

--- a/includes/class-paystack-give.php
+++ b/includes/class-paystack-give.php
@@ -228,62 +228,6 @@ class Paystack_Give
 
         add_filter('give_payment_gateways', 'give_paystack_register_gateway', 1);
 
-        function give_paystack_settings($settings)
-        {
-
-            $check_settings = array(
-                array(
-                    'name' => __('Paystack', 'paystack-give'),
-                    'desc' => '',
-                    'type' => 'give_title',
-                    'id' => 'give_title_paystack',
-                ),
-                array(
-                    'name' => __('Test Secret Key', 'paystack-give'),
-                    'desc' => __('Enter your Paystack Test Secret Key', 'paystack-give'),
-                    'id' => 'paystack_test_secret_key',
-                    'type' => 'text',
-                    'row_classes' => 'give-paystack-test-secret-key',
-                ),
-                array(
-                    'name' => __('Test Public Key', 'paystack-give'),
-                    'desc' => __('Enter your Paystack Test Public Key', 'paystack-give'),
-                    'id' => 'paystack_test_public_key',
-                    'type' => 'text',
-                    'row_classes' => 'give-paystack-test-public-key',
-                ),
-                array(
-                    'name' => __('Live Secret Key', 'paystack-give'),
-                    'desc' => __('Enter your Paystack Live Secret Key', 'paystack-give'),
-                    'id' => 'paystack_live_secret_key',
-                    'type' => 'text',
-                    'row_classes' => 'give-paystack-live-secret-key',
-                ),
-                array(
-                    'name' => __('Live Public Key', 'paystack-give'),
-                    'desc' => __('Enter your Paystack Live Public Key', 'paystack-give'),
-                    'id' => 'paystack_live_public_key',
-                    'type' => 'text',
-                    'row_classes' => 'give-paystack-live-public-key',
-                ),
-                array(
-                    'name' => __('Billing Details', 'paystack-give'),
-                    'desc' => __('This will enable you to collect donor details. This is not required by Paystack (except email) but you might need to collect all information for record purposes', 'paystack-give'),
-                    'id' => 'paystack_billing_details',
-                    'type' => 'radio_inline',
-                    'default' => 'disabled',
-                    'options' => array(
-                        'enabled' => __('Enabled', 'paystack-give'),
-                        'disabled' => __('Disabled', 'paystack-give'),
-                    ),
-                ),
-            );
-
-            return array_merge($settings, $check_settings);
-        }
-
-        add_filter('give_settings_gateways', 'give_paystack_settings');
-
         /**
          * Filter the currencies
          * Note: you can register new currency by using this filter


### PR DESCRIPTION
This PR Resolves #6 

I have improved the way admin settings for Paystack is currently implemented for GiveWP. I have ensured that the implementation of admin settings is as per the GiveWP standards.

## Visuals
![image](https://user-images.githubusercontent.com/1852711/104217143-0527fe00-5461-11eb-96cd-b12b3b27c34b.png)

Let me know if there is any change in this PR.